### PR TITLE
Ignore url fetching a git repository.

### DIFF
--- a/lib/brew2deb/vendor/homebrew/Library/Homebrew/download_strategy.rb
+++ b/lib/brew2deb/vendor/homebrew/Library/Homebrew/download_strategy.rb
@@ -317,7 +317,7 @@ class GitDownloadStrategy < AbstractDownloadStrategy
     else
       puts "Updating #{@clone}"
       Dir.chdir(@clone) do
-        quiet_safe_system 'git', 'fetch', @url
+        quiet_safe_system 'git', 'fetch'
         # If we're going to checkout a tag, then we need to fetch new tags too.
         quiet_safe_system 'git', 'fetch', '--tags' if @spec == :tag
       end


### PR DESCRIPTION
Otherwise the branch strategy doesn't work properly.
